### PR TITLE
TASK 020: CORRECCIÓN DE ANOTACIONES

### DIFF
--- a/src/main/java/acme/entities/Chirp.java
+++ b/src/main/java/acme/entities/Chirp.java
@@ -1,13 +1,16 @@
 package acme.entities;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
+
+import org.hibernate.validator.constraints.Length;
 
 import acme.framework.entities.AbstractEntity;
 import lombok.Getter;
@@ -18,22 +21,27 @@ import lombok.Setter;
 @Setter
 public class Chirp extends AbstractEntity {
 	
+	// Serialisation identifier -----------------------------------------------
+	
 	protected static final long    serialVersionUID    = 1L;
+	
+	// Attributes -------------------------------------------------------------
 	
 	@NotNull
 	@Past
-	protected Date creationMoment;
+	@Temporal(TemporalType.TIMESTAMP)
+	protected LocalDateTime creationMoment;
 	
 	@NotBlank
-	@Column(length=101)
+	@Length(min = 1, max = 100)
 	protected String title;
 	
 	@NotBlank
-	@Column(length=101)
+	@Length(min = 1, max = 100)
 	protected String author;
 	
 	@NotBlank
-	//@Column(length=256)
+	@Length(min = 1, max = 255)
 	protected String body;
 	
 	@Email


### PR DESCRIPTION
Cambiadas las anotaciones @Column(length=*) por @Length(*) y el tipo
Date del creationMoment por LocalDateTime, añadiéndole también la
anotación @Temporal(TemporalType.TIMESTAMP).